### PR TITLE
Fix spawners being reset when world is unloaded.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@
         <img alt="Patreon" src="https://img.shields.io/badge/-Support_on_Patreon-F96854.svg?logo=patreon&style=flat&logoColor=white">
     </a> 
     <br>
-    <img alt="Latest" src="https://img.shields.io/badge/-ver_3.1.1-4078C0.svg?logo=github&style=flat&logoColor=white&color=blue&label=Latest&labelColor=black">
+    <img alt="Latest" src="https://img.shields.io/badge/dynamic/xml?label=version&query=string%28%2F%2F%2A%5Blocal-name%28.%29%3D%27version%27%20and%20namespace-uri%28.%29%3D%27http%3A%2F%2Fmaven.apache.org%2FPOM%2F4.0.0%27%5D%5B1%5D%29&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsongoda%2FEpicFarming%2Fmaster%2Fpom.xml&logo=github&style=flat&logoColor=white&color=blue&labelColor=black">
     <a href="https://app.codacy.com/gh/songoda/EpicFarming/dashboard">
         <img alt="quality" src="https://img.shields.io/codacy/grade/88eb57700298485482781b1bff439fec">
     </a>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <groupId>com.songoda</groupId>
     <artifactId>EpicFarming</artifactId>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.1.1b</version>
+    <version>3.1.2</version>
     <build>
         <defaultGoal>clean install</defaultGoal>
         <finalName>EpicFarming-${project.version}</finalName>

--- a/src/main/java/com/songoda/epicfarming/EpicFarming.java
+++ b/src/main/java/com/songoda/epicfarming/EpicFarming.java
@@ -32,11 +32,7 @@ import com.songoda.epicfarming.farming.levels.modules.Module;
 import com.songoda.epicfarming.farming.levels.modules.ModuleAutoBreeding;
 import com.songoda.epicfarming.farming.levels.modules.ModuleAutoButcher;
 import com.songoda.epicfarming.farming.levels.modules.ModuleAutoCollect;
-import com.songoda.epicfarming.listeners.BlockListeners;
-import com.songoda.epicfarming.listeners.EntityListeners;
-import com.songoda.epicfarming.listeners.InteractListeners;
-import com.songoda.epicfarming.listeners.InventoryListeners;
-import com.songoda.epicfarming.listeners.UnloadListeners;
+import com.songoda.epicfarming.listeners.*;
 import com.songoda.epicfarming.settings.Settings;
 import com.songoda.epicfarming.storage.Storage;
 import com.songoda.epicfarming.storage.StorageRow;
@@ -158,6 +154,7 @@ public class EpicFarming extends SongodaPlugin {
         pluginManager.registerEvents(new InteractListeners(this), this);
         pluginManager.registerEvents(new UnloadListeners(this), this);
         pluginManager.registerEvents(new InventoryListeners(), this);
+        pluginManager.registerEvents(new WorldListeners(this), this);
 
         if (pluginManager.isPluginEnabled("FabledSkyBlock")) {
             try {

--- a/src/main/java/com/songoda/epicfarming/EpicFarming.java
+++ b/src/main/java/com/songoda/epicfarming/EpicFarming.java
@@ -11,6 +11,7 @@ import com.songoda.core.database.SQLiteConnector;
 import com.songoda.core.gui.GuiManager;
 import com.songoda.core.hooks.EconomyManager;
 import com.songoda.core.hooks.EntityStackerManager;
+import com.songoda.core.hooks.ProtectionManager;
 import com.songoda.core.nms.NmsManager;
 import com.songoda.core.nms.nbt.NBTItem;
 import com.songoda.core.utils.TextUtils;
@@ -110,6 +111,9 @@ public class EpicFarming extends SongodaPlugin {
 
         // Load Economy
         EconomyManager.load();
+
+        // Load protection manager.
+        ProtectionManager.load(this);
 
         // Setup Config
         Settings.setupConfig();

--- a/src/main/java/com/songoda/epicfarming/farming/Farm.java
+++ b/src/main/java/com/songoda/epicfarming/farming/Farm.java
@@ -65,6 +65,14 @@ public class Farm {
         EpicFarming.getInstance().getGuiManager().showGUI(player, opened);
     }
 
+    public void forceMenuClose() {
+        if (opened == null) {
+            return;
+        }
+
+        opened.close();
+    }
+
     public void upgrade(UpgradeType type, Player player) {
         EpicFarming instance = EpicFarming.getInstance();
         if (instance.getLevelManager().getLevels().containsKey(this.level.getLevel() + 1)) {

--- a/src/main/java/com/songoda/epicfarming/farming/Farm.java
+++ b/src/main/java/com/songoda/epicfarming/farming/Farm.java
@@ -4,6 +4,7 @@ import com.songoda.core.compatibility.CompatibleMaterial;
 import com.songoda.core.compatibility.CompatibleParticleHandler;
 import com.songoda.core.compatibility.CompatibleSound;
 import com.songoda.core.hooks.EconomyManager;
+import com.songoda.core.hooks.ProtectionManager;
 import com.songoda.epicfarming.EpicFarming;
 import com.songoda.epicfarming.farming.levels.Level;
 import com.songoda.epicfarming.gui.OverviewGui;
@@ -59,6 +60,11 @@ public class Farm {
             return;
 
         if (opened != null && !force) return;
+
+        if (Settings.USE_PROTECTION_PLUGINS.getBoolean() && !ProtectionManager.canInteract(player, location)) {
+            player.sendMessage(EpicFarming.getInstance().getLocale().getMessage("event.general.protected").getPrefixedMessage());
+            return;
+        }
 
         opened = new OverviewGui(this, player);
 

--- a/src/main/java/com/songoda/epicfarming/listeners/BlockListeners.java
+++ b/src/main/java/com/songoda/epicfarming/listeners/BlockListeners.java
@@ -112,6 +112,7 @@ public class BlockListeners implements Listener {
         if (farm == null) return;
 
         plugin.getDataManager().deleteFarm(farm);
+        farm.forceMenuClose();
 
         FarmTask.getCrops(farm, false);
 
@@ -140,6 +141,7 @@ public class BlockListeners implements Listener {
         FarmTask.getCrops(farm, false);
 
         plugin.getDataManager().deleteFarm(farm);
+        farm.forceMenuClose();
 
         event.setCancelled(true);
 

--- a/src/main/java/com/songoda/epicfarming/listeners/EntityListeners.java
+++ b/src/main/java/com/songoda/epicfarming/listeners/EntityListeners.java
@@ -110,6 +110,7 @@ public class EntityListeners implements Listener {
 
             Farm farm = plugin.getFarmManager().removeFarm(block.getLocation());
             plugin.getDataManager().deleteFarm(farm);
+            farm.forceMenuClose();
 
             FarmTask.getCrops(farm, false);
 

--- a/src/main/java/com/songoda/epicfarming/listeners/WorldListeners.java
+++ b/src/main/java/com/songoda/epicfarming/listeners/WorldListeners.java
@@ -1,0 +1,55 @@
+package com.songoda.epicfarming.listeners;
+
+import com.songoda.epicfarming.EpicFarming;
+import com.songoda.epicfarming.farming.Farm;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Created by noahvdaa on 5/21/2021.
+ */
+public class WorldListeners implements Listener {
+
+	private final EpicFarming plugin;
+
+	public WorldListeners(EpicFarming plugin) {
+		this.plugin = plugin;
+	}
+
+	@EventHandler
+	public void onWorldUnload(WorldUnloadEvent e){
+		for (Farm f : plugin.getFarmManager().getFarms().values()) {
+			if (e.getWorld().getName().equals(f.getLocation().getWorld().getName())) {
+				plugin.getFarmManager().removeFarm(f.getLocation());
+			}
+		}
+	}
+
+	@EventHandler
+	public void onWorldLoad(WorldLoadEvent e) {
+		// Unload previous farms belonging to this world.
+		for (Farm f : plugin.getFarmManager().getFarms().values()) {
+			if (e.getWorld().getName().equals(f.getLocation().getWorld().getName())) {
+				plugin.getFarmManager().removeFarm(f.getLocation());
+			}
+		}
+
+		// Load farms back in.
+		plugin.getDataManager().getFarms(new Consumer<Map<Integer, Farm>>() {
+			@Override
+			public void accept(Map<Integer, Farm> locationFarmMap) {
+				for (Farm f : locationFarmMap.values()) {
+					if (e.getWorld().getName().equals(f.getLocation().getWorld().getName())) {
+						plugin.getFarmManager().addFarm(f.getLocation(), f);
+					}
+				}
+			}
+		});
+	}
+
+}

--- a/src/main/java/com/songoda/epicfarming/settings/Settings.java
+++ b/src/main/java/com/songoda/epicfarming/settings/Settings.java
@@ -40,6 +40,9 @@ public class Settings {
     public static final ConfigSetting DISABLE_AUTO_TIL_LAND = new ConfigSetting(config, "Main.Disable Auto Til Land", false,
             "Should farms not auto til land around them?");
 
+    public static final ConfigSetting USE_PROTECTION_PLUGINS = new ConfigSetting(config, "Main.Use Protection Plugins", true,
+            "Should we use protection plugins?");
+
     public static final ConfigSetting ECONOMY_PLUGIN = new ConfigSetting(config, "Main.Economy", EconomyManager.getEconomy() == null ? "Vault" : EconomyManager.getEconomy().getName(),
             "Which economy plugin should be used?",
             "Supported plugins you have installed: \"" + EconomyManager.getManager().getRegisteredPlugins().stream().collect(Collectors.joining("\", \"")) + "\".");

--- a/src/main/resources/en_US.lang
+++ b/src/main/resources/en_US.lang
@@ -50,6 +50,7 @@ command:
 event:
   general:
     nopermission: '&cYou do not have permission to do that.'
+    protected: '&cThis farm is protected and you cannot access it.'
   upgrade:
     cannotafford: '&cYou cannot afford this upgrade.'
     success: '&7You successfully upgraded this farm to &6level %level%&7!'


### PR DESCRIPTION
Fixes the same issue as [Songoda/EpicSpawners#6](https://github.com/songoda/EpicSpawners/pull/6), except that it has an extra on world unload event to prevent NPE's in the FarmTask.